### PR TITLE
Add auto executable build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
-  build_for_pc:
+  build_for_linux_mac:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -59,6 +59,32 @@ jobs:
           git clone https://github.com/arthuro555/gdexporter
           cd gdexporter
           rm -rf Project
+          git clone https://github.com/Gdevelop-game/GDevelop-Open-Game Project
+          npm i
+          node bin/cli.js -b electron -p "./Project/src/game.json"
+          
+      - name: Build Electron app
+        uses: samuelmeuli/action-electron-builder@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          app_root: gdexporter/Exported
+          package_root: gdexporter/Exported
+          
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          # Upload all potential executables
+          path: gdexporter/Exported/dist/*.*
+          
+  build_for_windows:
+    runs-on: windows-latest
+      
+    steps:
+      - name: Build with GDexport
+        run: |
+          git clone https://github.com/arthuro555/gdexporter
+          cd gdexporter
+          rmdir Project
           git clone https://github.com/Gdevelop-game/GDevelop-Open-Game Project
           npm i
           node bin/cli.js -b electron -p "./Project/src/game.json"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           cd gdexporter/Exported
           npm i --save-dev electron-builder
-          ./node_modules/.bin/electron-builder -wml
+          ./node_modules/.bin/electron-builder -ml
           
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2
@@ -92,7 +92,7 @@ jobs:
         run: |
           cd gdexporter/Exported
           npm i --save-dev electron-builder
-          .\node_modules\.bin\electron-builder.cmd -wml
+          .\node_modules\.bin\electron-builder.cmd -w portable
           
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build and deploy to pages:
+  build_and_deploy_to_pages:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     
@@ -45,7 +45,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
-  build for pc:
+  build_for_pc:
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,12 +45,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
-  build_for_linux_mac:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest]
+  build_for_linux:
+    runs-on: ubuntu-latest
         
     steps:
       
@@ -67,7 +63,33 @@ jobs:
         run: |
           cd gdexporter/Exported
           npm i --save-dev electron-builder
-          ./node_modules/.bin/electron-builder -ml
+          ./node_modules/.bin/electron-builder -l
+          
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          # Upload all potential executables
+          path: gdexporter/Exported/dist/*.*
+          
+  build_for_mac:
+    runs-on: macos-latest
+        
+    steps:
+      
+      - name: Build with GDexport
+        run: |
+          git clone https://github.com/arthuro555/gdexporter
+          cd gdexporter
+          rm -rf Project
+          git clone https://github.com/Gdevelop-game/GDevelop-Open-Game Project
+          npm i
+          node bin/cli.js -b electron -p "./Project/src/game.json"
+          
+      - name: Build Electron app
+        run: |
+          cd gdexporter/Exported
+          npm i --save-dev electron-builder
+          ./node_modules/.bin/electron-builder -m
           
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
         
     steps:
       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           git clone https://github.com/arthuro555/gdexporter
           cd gdexporter
-          rmdir Project
+          rd /s /q Project
           git clone https://github.com/Gdevelop-game/GDevelop-Open-Game Project
           npm i
           node bin/cli.js -b electron -p "./Project/src/game.json"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,11 +64,10 @@ jobs:
           node bin/cli.js -b electron -p "./Project/src/game.json"
           
       - name: Build Electron app
-        uses: samuelmeuli/action-electron-builder@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          app_root: gdexporter/Exported
-          package_root: gdexporter/Exported
+        run: |
+          cd gdexporter/Exported
+          npm i --dev electron-builder
+          ./node_modules/.bin/electron-builder -wml
           
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2
@@ -90,11 +89,10 @@ jobs:
           node bin/cli.js -b electron -p "./Project/src/game.json"
           
       - name: Build Electron app
-        uses: samuelmeuli/action-electron-builder@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          app_root: gdexporter/Exported
-          package_root: gdexporter/Exported
+        run: |
+          cd gdexporter/Exported
+          npm i --dev electron-builder
+          .\node_modules\.bin\electron-builder.cmd -wml
           
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           app_root: gdexporter/Exported
+          package_root: gdexporter/Exported
           
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,12 @@ name: Auto Build
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches: [ master, add-electron-build ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  build and deploy to pages:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     
@@ -19,11 +19,11 @@ jobs:
     steps:
     
     # Set Up Node
-    - name: Setup Node.js environment
+    - name: Setup Node.js
       uses: actions/setup-node@v1.4.2
 
     # Runs a set of commands using the runners shell
-    - name: Run a multi-line script
+    - name: Build with GDexport
       run: |
         git clone https://github.com/arthuro555/gdexporter
         cd gdexporter
@@ -33,7 +33,7 @@ jobs:
         npm link
         gdexport -b -p "./Project/src/game.json"
       
-    - name: GitHub Pages
+    - name: Upload to GitHub Pages
       uses: crazy-max/ghaction-github-pages@v2.0.1
       with:
         # Build directory to deploy
@@ -44,3 +44,34 @@ jobs:
         commit_message: Auto Built nightly game build
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+  build for pc:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        
+    steps:
+      
+      - name: Build with GDexport
+        run: |
+          git clone https://github.com/arthuro555/gdexporter
+          cd gdexporter
+          rm -rf Project
+          git clone https://github.com/Gdevelop-game/GDevelop-Open-Game Project
+          npm i
+          npm link
+          gdexport -b electron -p "./Project/src/game.json"
+          
+      - name: Build Electron app
+        uses: samuelmeuli/action-electron-builder@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          app_root: gdexporter/Exported
+          
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          # Upload all potential executables
+          path: gdexporter/Exported/dist/*.*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,13 +63,13 @@ jobs:
         run: |
           cd gdexporter/Exported
           npm i --save-dev electron-builder
-          ./node_modules/.bin/electron-builder -l
+          ./node_modules/.bin/electron-builder -l AppImage
           
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2
         with:
           # Upload all potential executables
-          path: gdexporter/Exported/dist/*.*
+          path: gdexporter/Exported/dist/*.AppImage
           
   build_for_mac:
     runs-on: macos-latest
@@ -89,13 +89,13 @@ jobs:
         run: |
           cd gdexporter/Exported
           npm i --save-dev electron-builder
-          ./node_modules/.bin/electron-builder -m
+          ./node_modules/.bin/electron-builder -m dmg
           
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2
         with:
           # Upload all potential executables
-          path: gdexporter/Exported/dist/*.*
+          path: gdexporter/Exported/dist/*.dmg
           
   build_for_windows:
     runs-on: windows-latest
@@ -120,4 +120,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           # Upload all potential executables
-          path: gdexporter/Exported/dist/*.*
+          path: gdexporter/Exported/dist/*.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ name: Auto Build
 # events but only for the master branch
 on:
   push:
-    branches: [ master, add-electron-build ]
+    branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Build Electron app
         run: |
           cd gdexporter/Exported
-          npm i --dev electron-builder
+          npm i --save-dev electron-builder
           ./node_modules/.bin/electron-builder -wml
           
       - name: Upload a Build Artifact
@@ -91,7 +91,7 @@ jobs:
       - name: Build Electron app
         run: |
           cd gdexporter/Exported
-          npm i --dev electron-builder
+          npm i --save-dev electron-builder
           .\node_modules\.bin\electron-builder.cmd -wml
           
       - name: Upload a Build Artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,8 +61,7 @@ jobs:
           rm -rf Project
           git clone https://github.com/Gdevelop-game/GDevelop-Open-Game Project
           npm i
-          npm link
-          gdexport -b electron -p "./Project/src/game.json"
+          node bin/cli.js -b electron -p "./Project/src/game.json"
           
       - name: Build Electron app
         uses: samuelmeuli/action-electron-builder@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           git clone https://github.com/arthuro555/gdexporter
           cd gdexporter
-          rd /s /q Project
+          Remove-Item -Recurse -Force Project
           git clone https://github.com/Gdevelop-game/GDevelop-Open-Game Project
           npm i
           node bin/cli.js -b electron -p "./Project/src/game.json"


### PR DESCRIPTION
Adds auto build for windows, mac and linux.
Auto build files can be found at: https://github.com/Gdevelop-game/GDevelop-Open-Game/actions/, click on latest commit and click on artifact. It will download a zip with an executable for mac, windows and linux.